### PR TITLE
Return callable reference from `add_filter_side_effect`

### DIFF
--- a/src/alley/wp/filter-side-effects.php
+++ b/src/alley/wp/filter-side-effects.php
@@ -19,10 +19,12 @@ namespace Alley\WP;
  * @param callable $function_to_add Callback.
  * @param int      $priority        Priority.
  * @param int      $accepted_args   Accepted arguments.
- * @return true|void
+ * @return callable
  */
-function add_filter_side_effect( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-	return add_filter( $tag, generate_filter_side_effect( $function_to_add ), $priority, $accepted_args );
+function add_filter_side_effect( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ): callable {
+	$fn = generate_filter_side_effect( $function_to_add );
+	add_filter( $tag, $fn, $priority, $accepted_args );
+	return $fn;
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes it easier to eventually remove the filter if needed, which can be hard to achieve if we have no reference for the closure.

Example:
```php
$fn = add_filter_side_effect('filter', 'function');
remove_filter('filter', $fn);
```

## Notes for reviewers

Since `add_filter` always return `true` and has no real benefit, It's ok (IMHO) to change the function signature here. Although it will trigger a new major update.

## Changelog entries

### Added

### Changed

`add_filter_side_effect` signature changed and now returns the generated callable.

### Deprecated

### Removed

### Fixed

### Security
