### PR TITLE
Remove root-level Alley\ namespace inclusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,6 @@
   },
   "extra": {
     "wordpress-autoloader": {
-      "autoload": {
-        "Alley\\": "src/alley/"
-      },
       "autoload-dev": {
         "Alley\\": "tests/alley/"
       }


### PR DESCRIPTION
Remove the `Alley\` namespace autoloading from the package. It is unused and a bit too broad.